### PR TITLE
Use craft-password-policy validation on empty passwords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "rias/craft-password-policy",
     "description": "Enforce a password policy on your users.",
     "type": "craft-plugin",
+    "version": "master",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "rias/craft-password-policy",
     "description": "Enforce a password policy on your users.",
     "type": "craft-plugin",
-    "version": "master",
     "keywords": [
         "craft",
         "cms",

--- a/src/PasswordPolicy.php
+++ b/src/PasswordPolicy.php
@@ -91,7 +91,7 @@ class PasswordPolicy extends Plugin
             User::class,
             User::EVENT_BEFORE_VALIDATE,
             function (ModelEvent $event) {
-                if ($event->sender->newPassword) {
+                if (!$event->sender->newPassword) {
                     $errors = $this->passwordService->getValidationErrors($event->sender->newPassword);
                     $event->isValid = count($errors) === 0;
 


### PR DESCRIPTION
Allow the craft-password-policy validation to run on empty passwords so that the proper error messaging appears. This is a proposed fix for issue #7.