### PR TITLE
fix: set `useForAllRequests` to `true`, closes: https://github.com/craftpulse/craft-password-policy/issues/34

### DIFF
--- a/src/PasswordPolicy.php
+++ b/src/PasswordPolicy.php
@@ -28,21 +28,16 @@ use craft\services\Utilities;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
-
 use craftpulse\passwordpolicy\assetbundles\passwordpolicy\PasswordPolicyAsset;
 use craftpulse\passwordpolicy\models\SettingsModel;
 use craftpulse\passwordpolicy\rules\UserRules;
 use craftpulse\passwordpolicy\services\ServicesTrait;
 use craftpulse\passwordpolicy\utilities\RetentionUtility;
 use craftpulse\passwordpolicy\variables\PasswordPolicyVariable;
-
 use Monolog\Formatter\LineFormatter;
-
-use nystudio107\pluginvite\services\VitePluginService;
 use nystudio107\pluginvite\services\ViteService;
 use Psr\Log\LogLevel;
 use Throwable;
-use Yii;
 use yii\base\Event;
 use yii\base\InvalidRouteException;
 use yii\log\Dispatcher;
@@ -77,29 +72,25 @@ class PasswordPolicy extends Plugin
     // Public Properties
     // =========================================================================
     /**
+     * @var null|SettingsModel
+     */
+    public static ?SettingsModel $settings = null;
+    /**
      * @var string
      */
     public string $schemaVersion = '1.0.0';
-
     /**
      * @var bool
      */
     public bool $hasCpSection = true;
-
     /**
      * @var bool
      */
     public bool $hasCpSettings = true;
-
     /**
      * @var mixed|object|null
      */
     public mixed $queue = null;
-
-    /**
-     * @var null|SettingsModel
-     */
-    public static ?SettingsModel $settings = null;
 
     public function init(): void
     {
@@ -208,7 +199,7 @@ class PasswordPolicy extends Plugin
     {
         return Craft::$app->getView()->renderTemplate(
             'password-policy/_settings',
-            [ 'settings' => $this->getSettings() ]
+            ['settings' => $this->getSettings()]
         );
     }
 
@@ -284,13 +275,6 @@ class PasswordPolicy extends Plugin
                 // Register Asset Bundle
                 $view->registerAssetBundle(PasswordPolicyAsset::class);
 
-                //$tagOptions = [
-                //    'depends' => [
-                //        'craftpulse\\passwordpolicy\\assetbundles\\passwordpolicy\\PasswordPolicyAsset'
-                //    ],
-                //];
-                $manifestPath = '@craftpulse/passwordpolicy/web/assets/dist/';
-                $this->vite->manifestPath = rtrim(Yii::getAlias($manifestPath), '/\\');
                 //$this->vite->manifestPath = $manifestPath;
                 $this->vite->register('src/js/indicator.ts', false);
             }

--- a/src/services/ServicesTrait.php
+++ b/src/services/ServicesTrait.php
@@ -28,6 +28,7 @@ trait ServicesTrait
                 'vite' => [
                     'assetClass' => PasswordPolicyAsset::class,
                     'checkDevServer' => true,
+                    'useForAllRequests' => true,
                     'class' => VitePluginService::class,
                     'devServerInternal' => 'http://craft-password-policy-v5-buildchain-dev:3005',
                     'devServerPublic' => 'http://localhost:3005',


### PR DESCRIPTION
This PR sets `useForAllRequests` to `true`, in `ServicesTrait`, closes: https://github.com/craftpulse/craft-password-policy/issues/34

As per the code: 

```php
        // The Vite service is generally only needed for CP requests & previews, save a db write, see:
        // https://github.com/nystudio107/craft-plugin-vite/issues/27
        $request = Craft::$app->getRequest();
        if (!$this->useForAllRequests && !$request->getIsConsoleRequest()) {
            if (!$request->getIsCpRequest() && !$request->getIsPreview() && !in_array($request->getSegment(1), $this->firstSegmentRequests, true)) {
                return;
            }
        }
```

...by default `craft-plugin-vite` only works for CP requests. You can override this via the setting above. This was added to address this issue: https://github.com/nystudio107/craft-plugin-vite/issues/27