### PR TITLE
fix: security, bug fixes, and code quality sweep (v5.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Release Notes for Password Policy
 
+## 5.1.1 - 2026-04-17
+### Changed
+- Symbols regex now accepts any non-alphanumeric character (hyphens, underscores, etc.) instead of a limited set [#46](https://github.com/craftpulse/craft-password-policy/issues/46)
+- Console `force-reset-passwords` command now runs synchronously by default; use `--queue` to push to the queue instead [#60](https://github.com/craftpulse/craft-password-policy/issues/60)
+- Password expiry query now filters at the database level instead of hydrating all users into memory [#50](https://github.com/craftpulse/craft-password-policy/issues/50)
+- Replaced `switch` with `match` expression in `PasswordResetHelper` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
+- Applied coding conventions: section headers, `@author` on methods, `@throws` annotations, underscore-prefixed private members [#51](https://github.com/craftpulse/craft-password-policy/issues/51) [#52](https://github.com/craftpulse/craft-password-policy/issues/52) [#53](https://github.com/craftpulse/craft-password-policy/issues/53)
+
+### Fixed
+- Fixed a critical security issue where `RetentionController` had CSRF disabled and allowed anonymous access, enabling unauthenticated mass password resets [#47](https://github.com/craftpulse/craft-password-policy/issues/47)
+- Fixed `RetentionController::afterAction()` blocking web requests by synchronously draining the entire queue [#48](https://github.com/craftpulse/craft-password-policy/issues/48)
+- Fixed admin account exclusion being hardcoded to user ID 1 instead of using the `admin` property [#49](https://github.com/craftpulse/craft-password-policy/issues/49)
+- Fixed `getCpNavItem()` null dereference when no user is authenticated [#54](https://github.com/craftpulse/craft-password-policy/issues/54)
+- Fixed static `$settings` property never being populated [#55](https://github.com/craftpulse/craft-password-policy/issues/55)
+- Fixed `SettingsController::actionSave()` running permission checks before `requirePostRequest()` [#56](https://github.com/craftpulse/craft-password-policy/issues/56)
+- Fixed `SettingsModel::defineRules()` not calling `parent::defineRules()` [#59](https://github.com/craftpulse/craft-password-policy/issues/59)
+- Fixed console `force-reset-passwords` returning `ExitCode::OK` when retention features are disabled [#60](https://github.com/craftpulse/craft-password-policy/issues/60)
+- Fixed double `Craft::t()` nesting in `UserRules` that broke non-English translations [#61](https://github.com/craftpulse/craft-password-policy/issues/61)
+- Fixed `SecurityService` class docblock saying "RetentionService" [#58](https://github.com/craftpulse/craft-password-policy/issues/58)
+- Removed dead `$users` property from `PasswordResetJob` [#57](https://github.com/craftpulse/craft-password-policy/issues/57)
+- Removed dead `$vacancyId` parameter from `RetentionController::getFailureResponse()` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
+- Removed no-op `EVENT_AFTER_SAVE_PLUGIN_SETTINGS` handler [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
+- Replaced redundant ternary with `isNotEmpty()` in `PasswordService::pwned()` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
+- Fixed `PasswordPolicyAsset` using property access instead of getter for view [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
+- Fixed `$queue` property type from `mixed|object|null` to `?object` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
+
 ## 5.1.0 - 2025-10-28
 ### Added
 - Added optional CSP (Content Security Policy) nonce support for the password indicator script [#39](https://github.com/craftpulse/craft-password-policy/issues/39)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,28 @@
 ## 5.1.1 - 2026-04-17
 ### Changed
 - Symbols regex now accepts any non-alphanumeric character (hyphens, underscores, etc.) instead of a limited set [#46](https://github.com/craftpulse/craft-password-policy/issues/46)
-- Console `force-reset-passwords` command now runs synchronously by default; use `--queue` to push to the queue instead [#60](https://github.com/craftpulse/craft-password-policy/issues/60)
-- Password expiry query now filters at the database level instead of hydrating all users into memory [#50](https://github.com/craftpulse/craft-password-policy/issues/50)
-- Replaced `switch` with `match` expression in `PasswordResetHelper` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
-- Applied coding conventions: section headers, `@author` on methods, `@throws` annotations, underscore-prefixed private members [#51](https://github.com/craftpulse/craft-password-policy/issues/51) [#52](https://github.com/craftpulse/craft-password-policy/issues/52) [#53](https://github.com/craftpulse/craft-password-policy/issues/53)
+- Console `force-reset-passwords` command now runs synchronously by default; use `--queue` to push to the queue instead
+- Password expiry query now filters at the database level instead of hydrating all users into memory
+- Replaced `switch` with `match` expression in `PasswordResetHelper`
+- Applied coding conventions: section headers, `@author` on methods, `@throws` annotations, underscore-prefixed private members
 
 ### Fixed
-- Fixed a critical security issue where `RetentionController` had CSRF disabled and allowed anonymous access, enabling unauthenticated mass password resets [#47](https://github.com/craftpulse/craft-password-policy/issues/47)
-- Fixed `RetentionController::afterAction()` blocking web requests by synchronously draining the entire queue [#48](https://github.com/craftpulse/craft-password-policy/issues/48)
-- Fixed admin account exclusion being hardcoded to user ID 1 instead of using the `admin` property [#49](https://github.com/craftpulse/craft-password-policy/issues/49)
-- Fixed `getCpNavItem()` null dereference when no user is authenticated [#54](https://github.com/craftpulse/craft-password-policy/issues/54)
-- Fixed static `$settings` property never being populated [#55](https://github.com/craftpulse/craft-password-policy/issues/55)
-- Fixed `SettingsController::actionSave()` running permission checks before `requirePostRequest()` [#56](https://github.com/craftpulse/craft-password-policy/issues/56)
-- Fixed `SettingsModel::defineRules()` not calling `parent::defineRules()` [#59](https://github.com/craftpulse/craft-password-policy/issues/59)
-- Fixed console `force-reset-passwords` returning `ExitCode::OK` when retention features are disabled [#60](https://github.com/craftpulse/craft-password-policy/issues/60)
-- Fixed double `Craft::t()` nesting in `UserRules` that broke non-English translations [#61](https://github.com/craftpulse/craft-password-policy/issues/61)
-- Fixed `SecurityService` class docblock saying "RetentionService" [#58](https://github.com/craftpulse/craft-password-policy/issues/58)
-- Removed dead `$users` property from `PasswordResetJob` [#57](https://github.com/craftpulse/craft-password-policy/issues/57)
-- Removed dead `$vacancyId` parameter from `RetentionController::getFailureResponse()` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
-- Removed no-op `EVENT_AFTER_SAVE_PLUGIN_SETTINGS` handler [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
-- Replaced redundant ternary with `isNotEmpty()` in `PasswordService::pwned()` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
-- Fixed `PasswordPolicyAsset` using property access instead of getter for view [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
-- Fixed `$queue` property type from `mixed|object|null` to `?object` [#62](https://github.com/craftpulse/craft-password-policy/issues/62)
+- Fixed a critical security issue where `RetentionController` had CSRF disabled and allowed anonymous access, enabling unauthenticated mass password resets
+- Fixed `RetentionController::afterAction()` blocking web requests by synchronously draining the entire queue
+- Fixed admin account exclusion being hardcoded to user ID 1 instead of using the `admin` property
+- Fixed `getCpNavItem()` null dereference when no user is authenticated
+- Fixed static `$settings` property never being populated
+- Fixed `SettingsController::actionSave()` running permission checks before `requirePostRequest()`
+- Fixed `SettingsModel::defineRules()` not calling `parent::defineRules()`
+- Fixed console `force-reset-passwords` returning `ExitCode::OK` when retention features are disabled
+- Fixed double `Craft::t()` nesting in `UserRules` that broke non-English translations
+- Fixed `SecurityService` class docblock saying "RetentionService"
+- Removed dead `$users` property from `PasswordResetJob`
+- Removed dead `$vacancyId` parameter from `RetentionController::getFailureResponse()`
+- Removed no-op `EVENT_AFTER_SAVE_PLUGIN_SETTINGS` handler
+- Replaced redundant ternary with `isNotEmpty()` in `PasswordService::pwned()`
+- Fixed `PasswordPolicyAsset` using property access instead of getter for view
+- Fixed `$queue` property type from `mixed|object|null` to `?object`
 
 ## 5.1.0 - 2025-10-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Changed
 - Symbols regex now accepts any non-alphanumeric character (hyphens, underscores, etc.) instead of a limited set [#46](https://github.com/craftpulse/craft-password-policy/issues/46)
 - Console `force-reset-passwords` command now runs synchronously by default; use `--queue` to push to the queue instead
-- Password expiry query now filters at the database level instead of hydrating all users into memory
+- Password expiry query now filters at the database level instead of hydrating all users into memory, significantly improving performance on large user bases
 - Replaced `switch` with `match` expression in `PasswordResetHelper`
 - Applied coding conventions: section headers, `@author` on methods, `@throws` annotations, underscore-prefixed private members
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes for Password Policy
 
-## 5.1.1 - 2026-04-17
+## 5.1.1 - 2026-05-02
 ### Changed
 - Symbols regex now accepts any non-alphanumeric character (hyphens, underscores, etc.) instead of a limited set [#46](https://github.com/craftpulse/craft-password-policy/issues/46)
 - Console `force-reset-passwords` command now runs synchronously by default; use `--queue` to push to the queue instead

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "craftpulse/craft-password-policy",
     "description": "Password Policy plugin",
     "type": "craft-plugin",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "keywords": [
         "craft",
         "cms",
@@ -50,7 +50,8 @@
         "developerUrl": "https://craft-pulse.com",
         "documentationUrl": "https://github.com/craftpulse/craft-password-policy/blob/v5/README.md",
         "changelogUrl": "https://github.com/craftpulse/craft-password-policy/blob/v5/CHANGELOG.md",
-        "class": "craftpulse\\passwordpolicy\\PasswordPolicy"
+        "class": "craftpulse\\passwordpolicy\\PasswordPolicy",
+        "craftcms-claude-skills": "1.2.0"
     },
     "scripts": {
         "phpstan": "phpstan --ansi --memory-limit=1G",

--- a/src/PasswordPolicy.php
+++ b/src/PasswordPolicy.php
@@ -15,7 +15,6 @@ use craft\base\Model;
 use craft\base\Plugin;
 use craft\elements\User;
 use craft\events\DefineRulesEvent;
-use craft\events\PluginEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterUserPermissionsEvent;
@@ -23,7 +22,6 @@ use craft\events\TemplateEvent;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Json;
 use craft\log\MonologTarget;
-use craft\services\Plugins;
 use craft\services\UserPermissions;
 use craft\services\Utilities;
 use craft\web\twig\variables\CraftVariable;
@@ -39,6 +37,7 @@ use Monolog\Formatter\LineFormatter;
 use Psr\Log\LogLevel;
 use Throwable;
 use yii\base\Event;
+use yii\base\InvalidConfigException;
 use yii\base\InvalidRouteException;
 use yii\log\Dispatcher;
 use yii\log\Logger;
@@ -61,6 +60,7 @@ class PasswordPolicy extends Plugin
 
     // Static Properties
     // =========================================================================
+
     /**
      * @var ?PasswordPolicy
      */
@@ -68,37 +68,44 @@ class PasswordPolicy extends Plugin
 
     // Public Properties
     // =========================================================================
-    /**
-     * @var null|SettingsModel
-     */
-    public static ?SettingsModel $settings = null;
+
     /**
      * @var string
      */
     public string $schemaVersion = '1.0.0';
+
     /**
      * @var bool
      */
     public bool $hasCpSection = true;
+
     /**
      * @var bool
      */
     public bool $hasCpSettings = true;
-    /**
-     * @var mixed|object|null
-     */
-    public mixed $queue = null;
 
-    // Private Properties
+    /**
+     * @var ?object
+     */
+    public ?object $queue = null;
+
+    // Public Methods
     // =========================================================================
 
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidConfigException
+     *
+     * @author CraftPulse
+     */
     public function init(): void
     {
         parent::init();
         self::$plugin = $this;
 
         // Register custom log target
-        $this->registerLogTarget();
+        $this->_registerLogTarget();
 
         $request = Craft::$app->getRequest();
         if ($request->getIsConsoleRequest()) {
@@ -106,12 +113,12 @@ class PasswordPolicy extends Plugin
         }
 
         // Install our global event handlers
-        $this->installEventHandlers();
+        $this->_installEventHandlers();
 
         // Register control panel events
         if (Craft::$app->getRequest()->getIsCpRequest()) {
-            $this->registerCpUrlRules();
-            $this->installCpEventHandlers();
+            $this->_registerCpUrlRules();
+            $this->_installCpEventHandlers();
         }
 
         // Log that the plugin has loaded
@@ -125,8 +132,16 @@ class PasswordPolicy extends Plugin
     }
 
     /**
-     * Logs a message
+     * Logs a message.
+     *
+     * @param string $message
+     * @param array $params
+     * @param int $type
+     * @return void
+     *
      * @throws Throwable
+     *
+     * @author CraftPulse
      */
     public function log(string $message, array $params = [], int $type = Logger::LEVEL_INFO): void
     {
@@ -146,7 +161,10 @@ class PasswordPolicy extends Plugin
 
     /**
      * @inheritdoc
+     *
      * @throws InvalidRouteException
+     *
+     * @author CraftPulse
      */
     public function getSettingsResponse(): mixed
     {
@@ -155,13 +173,20 @@ class PasswordPolicy extends Plugin
 
     /**
      * @inheritdoc
+     *
      * @throws Throwable
+     *
+     * @author CraftPulse
      */
     public function getCpNavItem(): ?array
     {
         $subNavs = [];
         $navItem = parent::getCpNavItem();
         $currentUser = Craft::$app->getUser()->getIdentity();
+
+        if ($currentUser === null) {
+            return null;
+        }
 
         $editableSettings = true;
         $general = Craft::$app->getConfig()->getGeneral();
@@ -191,8 +216,13 @@ class PasswordPolicy extends Plugin
         ]);
     }
 
+    // Protected Methods
+    // =========================================================================
+
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     protected function settingsHtml(): ?string
     {
@@ -202,35 +232,28 @@ class PasswordPolicy extends Plugin
         );
     }
 
-    // Protected Methods
-    // =========================================================================
-
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     protected function createSettingsModel(): ?Model
     {
         return new SettingsModel();
     }
 
-    /**
-     * @return void
-     */
-    protected function installEventHandlers(): void
-    {
-        Event::on(
-            Plugins::class,
-            Plugins::EVENT_AFTER_SAVE_PLUGIN_SETTINGS,
-            function(PluginEvent $event) {
-                if ($event->plugin === $this) {
-                    Craft::debug(
-                        'Plugins::EVENT_AFTER_SAVE_PLUGIN_SETTINGS',
-                        __METHOD__
-                    );
-                }
-            }
-        );
+    // Private Methods
+    // =========================================================================
 
+    /**
+     * Installs global event handlers.
+     *
+     * @return void
+     *
+     * @author CraftPulse
+     */
+    private function _installEventHandlers(): void
+    {
         Event::on(
             CraftVariable::class,
             CraftVariable::EVENT_INIT,
@@ -259,14 +282,20 @@ class PasswordPolicy extends Plugin
             }
         );
 
-        $this->registerUserPermissions();
-        $this->registerUtilities();
+        $this->_registerUserPermissions();
+        $this->_registerUtilities();
     }
 
     /**
+     * Installs control panel event handlers.
+     *
      * @return void
+     *
+     * @throws InvalidConfigException
+     *
+     * @author CraftPulse
      */
-    protected function installCpEventHandlers(): void
+    private function _installCpEventHandlers(): void
     {
         // Load asset before page template is rendered
         Event::on(
@@ -278,20 +307,21 @@ class PasswordPolicy extends Plugin
 
                 // Register Asset Bundle
                 $view->registerAssetBundle(PasswordPolicyAsset::class);
-                $options = $this->settings->cspNonce ? ['nonce' => $this->getSecurity()->getNonce()] : [];
+                $options = $this->getSettings()->cspNonce ? ['nonce' => $this->getSecurity()->getNonce()] : [];
 
                 $this->vite->register('src/js/indicator.ts', false, $options);
             }
         );
     }
 
-    // Private Methods
-    // =========================================================================
-
     /**
-     * Registers CP URL rules event
+     * Registers CP URL rules.
+     *
+     * @return void
+     *
+     * @author CraftPulse
      */
-    private function registerCpUrlRules(): void
+    private function _registerCpUrlRules(): void
     {
         Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES,
             function(RegisterUrlRulesEvent $event) {
@@ -309,9 +339,13 @@ class PasswordPolicy extends Plugin
     }
 
     /**
-     * Registers user permissions
+     * Registers user permissions.
+     *
+     * @return void
+     *
+     * @author CraftPulse
      */
-    private function registerUserPermissions(): void
+    private function _registerUserPermissions(): void
     {
         Event::on(UserPermissions::class, UserPermissions::EVENT_REGISTER_PERMISSIONS,
             function(RegisterUserPermissionsEvent $event) {
@@ -330,9 +364,16 @@ class PasswordPolicy extends Plugin
         );
     }
 
-    private function registerUtilities(): void
+    /**
+     * Registers plugin utilities.
+     *
+     * @return void
+     *
+     * @author CraftPulse
+     */
+    private function _registerUtilities(): void
     {
-        if ($this->settings->retentionUtilities) {
+        if ($this->getSettings()->retentionUtilities) {
             Event::on(Utilities::class, Utilities::EVENT_REGISTER_UTILITIES,
                 function(RegisterComponentTypesEvent $event) {
                     $event->types[] = RetentionUtility::class;
@@ -342,11 +383,15 @@ class PasswordPolicy extends Plugin
     }
 
     /**
-     * Registers a custom log target
+     * Registers a custom log target.
+     *
+     * @return void
      *
      * @see LineFormatter::SIMPLE_FORMAT
+     *
+     * @author CraftPulse
      */
-    private function registerLogTarget(): void
+    private function _registerLogTarget(): void
     {
         if (Craft::getLogger()->dispatcher instanceof Dispatcher) {
             Craft::getLogger()->dispatcher->targets[] = new MonologTarget([

--- a/src/assetbundles/passwordpolicy/PasswordPolicyAsset.php
+++ b/src/assetbundles/passwordpolicy/PasswordPolicyAsset.php
@@ -32,6 +32,8 @@ class PasswordPolicyAsset extends AssetBundle
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function init(): void
     {
@@ -41,9 +43,9 @@ class PasswordPolicyAsset extends AssetBundle
         ];
 
         // Register Javascript variable with nonce support
-        Craft::$app->view->registerJs(
+        Craft::$app->getView()->registerJs(
             'window.passwordpolicy = ' . Json::encode([
-                'showStrengthIndicator' => PasswordPolicy::$plugin->settings->showStrengthIndicator,
+                'showStrengthIndicator' => PasswordPolicy::$plugin->getSettings()->showStrengthIndicator,
             ]) . ';',
             View::POS_HEAD
         );

--- a/src/batchers/PasswordResetBatcher.php
+++ b/src/batchers/PasswordResetBatcher.php
@@ -11,6 +11,7 @@
 namespace craftpulse\passwordpolicy\batchers;
 
 use craft\base\Batchable;
+use craft\elements\User;
 
 /**
  * Class PasswordResetBatcher
@@ -21,6 +22,16 @@ use craft\base\Batchable;
  */
 readonly class PasswordResetBatcher implements Batchable
 {
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Constructor.
+     *
+     * @param User[] $users
+     *
+     * @author CraftPulse
+     */
     public function __construct(
         private array $users,
     ) {
@@ -28,6 +39,8 @@ readonly class PasswordResetBatcher implements Batchable
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function count(): int
     {
@@ -36,6 +49,8 @@ readonly class PasswordResetBatcher implements Batchable
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function getSlice(int $offset, int $limit): iterable
     {

--- a/src/console/controllers/RetentionController.php
+++ b/src/console/controllers/RetentionController.php
@@ -11,9 +11,11 @@
 namespace craftpulse\passwordpolicy\console\controllers;
 
 use Craft;
+use craftpulse\passwordpolicy\helpers\PasswordResetHelper;
 use craftpulse\passwordpolicy\PasswordPolicy;
 
 use craftpulse\passwordpolicy\services\RetentionService;
+use Throwable;
 use yii\console\Controller;
 use yii\console\ExitCode;
 use yii\helpers\BaseConsole;
@@ -26,21 +28,29 @@ use yii\helpers\BaseConsole;
  * @since       5.0.0
  *
  * @property RetentionService $retention
-*/
+ */
 class RetentionController extends Controller
 {
+    // Public Properties
+    // =========================================================================
+
     /**
-     * @var bool Whether jobs should be only queued and not run.
+     * @var bool Whether jobs should be pushed to the queue instead of running synchronously.
      */
     public bool $queue = false;
 
     /**
-     * @var bool Whether verbose output should be enabled
+     * @var bool Whether verbose output should be enabled.
      */
     public bool $verbose = false;
 
+    // Public Methods
+    // =========================================================================
+
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function options($actionID): array
     {
@@ -53,6 +63,8 @@ class RetentionController extends Controller
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function getHelp(): string
     {
@@ -61,6 +73,8 @@ class RetentionController extends Controller
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function getHelpSummary(): string
     {
@@ -68,46 +82,66 @@ class RetentionController extends Controller
     }
 
     /**
-     * Force resets all passwords
+     * Force resets all passwords that have expired according to the retention settings.
+     *
      * @return int
+     *
+     * @throws Throwable
+     *
+     * @author CraftPulse
      */
     public function actionForceResetPasswords(): int
     {
-        if (!PasswordPolicy::$plugin->settings->retentionUtilities) {
+        if (!PasswordPolicy::$plugin->getSettings()->retentionUtilities) {
             $this->stderr(Craft::t('password-policy', 'Password retention features are disabled.') . PHP_EOL, BaseConsole::FG_RED);
+
+            return ExitCode::UNSPECIFIED_ERROR;
+        }
+
+        if ($this->queue) {
+            PasswordPolicy::$plugin->retention->resetPasswords();
+            $this->_output('Users queued for password resets.');
 
             return ExitCode::OK;
         }
 
-        $this->forceResetPasswords();
+        $this->stdout(Craft::t('password-policy', 'Resetting passwords...') . PHP_EOL, BaseConsole::FG_GREEN);
+
+        $users = PasswordResetHelper::getAllUsersToExpire();
+
+        if (empty($users)) {
+            $this->_output('No users require a password reset.');
+
+            return ExitCode::OK;
+        }
+
+        foreach ($users as $user) {
+            PasswordPolicy::$plugin->retention->requirePasswordReset($user);
+
+            if ($this->verbose) {
+                $this->stdout("  Reset required for: {$user->email}" . PHP_EOL);
+            }
+        }
+
+        $count = count($users);
+        $this->_output("Password resets complete. {$count} user(s) flagged.");
 
         return ExitCode::OK;
     }
 
+    // Private Methods
+    // =========================================================================
+
     /**
+     * Outputs a translated success message.
+     *
      * @param string $message
      * @return void
+     *
+     * @author CraftPulse
      */
-    private function output(string $message): void
+    private function _output(string $message): void
     {
         $this->stdout(Craft::t('password-policy', $message) . PHP_EOL, BaseConsole::FG_GREEN);
-    }
-
-    /**
-     * @param $users array
-     * @return void
-     */
-    private function forceResetPasswords(): void
-    {
-        if ($this->queue) {
-            PasswordPolicy::$plugin->retention->resetPasswords();
-            $this->output('Users queued for password resets.');
-
-            return;
-        }
-
-        $this->stdout(Craft::t('password-policy', 'Resetting passwords...') . PHP_EOL, BaseConsole::FG_GREEN);
-        PasswordPolicy::$plugin->retention->resetPasswords();
-        $this->output('Password resets complete.');
     }
 }

--- a/src/console/controllers/RetentionController.php
+++ b/src/console/controllers/RetentionController.php
@@ -98,11 +98,32 @@ class RetentionController extends Controller
             return ExitCode::UNSPECIFIED_ERROR;
         }
 
+        $this->_forceResetPasswords();
+
+        return ExitCode::OK;
+    }
+
+    // Private Methods
+    // =========================================================================
+
+    /**
+     * Handles the password reset logic.
+     *
+     * When `--queue` is set, jobs are pushed to the queue. Otherwise, resets run synchronously.
+     *
+     * @return void
+     *
+     * @throws Throwable
+     *
+     * @author CraftPulse
+     */
+    private function _forceResetPasswords(): void
+    {
         if ($this->queue) {
             PasswordPolicy::$plugin->retention->resetPasswords();
             $this->_output('Users queued for password resets.');
 
-            return ExitCode::OK;
+            return;
         }
 
         $this->stdout(Craft::t('password-policy', 'Resetting passwords...') . PHP_EOL, BaseConsole::FG_GREEN);
@@ -112,7 +133,7 @@ class RetentionController extends Controller
         if (empty($users)) {
             $this->_output('No users require a password reset.');
 
-            return ExitCode::OK;
+            return;
         }
 
         foreach ($users as $user) {
@@ -125,12 +146,7 @@ class RetentionController extends Controller
 
         $count = count($users);
         $this->_output("Password resets complete. {$count} user(s) flagged.");
-
-        return ExitCode::OK;
     }
-
-    // Private Methods
-    // =========================================================================
 
     /**
      * Outputs a translated success message.

--- a/src/controllers/RetentionController.php
+++ b/src/controllers/RetentionController.php
@@ -13,12 +13,11 @@ namespace craftpulse\passwordpolicy\controllers;
 use Craft;
 use craft\web\Controller;
 
-use craft\web\View;
 use craftpulse\passwordpolicy\PasswordPolicy;
 use craftpulse\passwordpolicy\services\RetentionService;
 use Throwable;
 use yii\web\BadRequestHttpException;
-
+use yii\web\ForbiddenHttpException;
 use yii\web\Response;
 
 /**
@@ -29,21 +28,19 @@ use yii\web\Response;
  * @since       5.0.0
  *
  * @property RetentionService $retention
-*/
+ */
 class RetentionController extends Controller
 {
-    /**
-     * @inheritdoc
-     */
-    public $enableCsrfValidation = false;
+    // Public Methods
+    // =========================================================================
 
     /**
      * @inheritdoc
-     */
-    protected array|bool|int $allowAnonymous = true;
-
-    /**
-     * @inheritdoc
+     *
+     * @throws BadRequestHttpException
+     * @throws ForbiddenHttpException
+     *
+     * @author CraftPulse
      */
     public function beforeAction($action): bool
     {
@@ -51,81 +48,90 @@ class RetentionController extends Controller
             return false;
         }
 
-        $request = Craft::$app->getRequest();
-
-        // Require permission if posted from the CP
-        if ($request->getIsPost() && $request->getIsCpRequest()) {
-            $this->requirePermission('pp:' . $action->id);
-        }
+        $this->requireCpRequest();
+        $this->requirePostRequest();
+        $this->requirePermission('pp:force-reset-passwords');
 
         return true;
     }
 
     /**
      * Forces the password resets.
+     *
+     * @return Response|null
+     *
+     * @throws BadRequestHttpException
+     * @throws Throwable
+     *
+     * @author CraftPulse
      */
     public function actionForceResetPasswords(): ?Response
     {
-        if (!PasswordPolicy::$plugin->settings->retentionUtilities) {
-            return $this->getFailureResponse('Password retention features are disabled.');
+        if (!PasswordPolicy::$plugin->getSettings()->retentionUtilities) {
+            return $this->_getFailureResponse('Password retention features are disabled.');
         }
 
         PasswordPolicy::$plugin->retention->resetPasswords();
 
-        return $this->getSuccessResponse('Users which will receive a password reset successfully queued.');
+        return $this->_getSuccessResponse('Users which will receive a password reset successfully queued.');
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function afterAction($action, $result): mixed
-    {
-        // If front-end request, run the queue to ensure action is completed in full
-        if (Craft::$app->getView()->templateMode == View::TEMPLATE_MODE_SITE) {
-            Craft::$app->runAction('queue/run');
-        }
-
-        return parent::afterAction($action, $result);
-    }
+    // Private Methods
+    // =========================================================================
 
     /**
+     * Returns a success response.
+     *
      * @param string $message
      * @return Response|null
+     *
      * @throws BadRequestHttpException
      * @throws Throwable
+     *
+     * @author CraftPulse
      */
-    private function getSuccessResponse(string $message): ?Response
+    private function _getSuccessResponse(string $message): ?Response
     {
         PasswordPolicy::$plugin->log($message . ' [via sync utility by "{username}"]');
 
         $this->setSuccessFlash(Craft::t('password-policy', $message));
 
-        return $this->getResponse($message);
+        return $this->_getResponse($message);
     }
 
     /**
-     * Returns a failure response
+     * Returns a failure response.
+     *
+     * @param string $message
+     * @return Response|null
+     *
      * @throws BadRequestHttpException
+     *
+     * @author CraftPulse
      */
-    private function getFailureResponse(string $message, ?int $vacancyId = null): ?Response
+    private function _getFailureResponse(string $message): ?Response
     {
         $this->setFailFlash(Craft::t('password-policy', $message));
 
-        return $this->getResponse($message, false);
+        return $this->_getResponse($message, false);
     }
 
     /**
+     * Returns a JSON or redirect response.
+     *
      * @param string $message
      * @param bool $success
      * @return Response|null
+     *
      * @throws BadRequestHttpException
+     *
+     * @author CraftPulse
      */
-    private function getResponse(string $message, bool $success = true): ?Response
+    private function _getResponse(string $message, bool $success = true): ?Response
     {
         $request = Craft::$app->getRequest();
 
-        // If front-end or JSON request
-        if (Craft::$app->getView()->templateMode == View::TEMPLATE_MODE_SITE || $request->getAcceptsJson()) {
+        if ($request->getAcceptsJson()) {
             return $this->asJson([
                 'success' => $success,
                 'message' => Craft::t('password-policy', $message),

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -16,6 +16,7 @@ use craft\web\Controller;
 use craft\web\UrlManager;
 
 use craftpulse\passwordpolicy\PasswordPolicy;
+use yii\web\BadRequestHttpException;
 use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;
@@ -29,8 +30,15 @@ use yii\web\Response;
  */
 class SettingsController extends Controller
 {
+    // Public Methods
+    // =========================================================================
+
     /**
      * @inheritdoc
+     *
+     * @throws ForbiddenHttpException
+     *
+     * @author CraftPulse
      */
     public function beforeAction($action): bool
     {
@@ -40,7 +48,13 @@ class SettingsController extends Controller
     }
 
     /**
+     * Renders the plugin settings form.
+     *
      * @return Response|null
+     *
+     * @throws ForbiddenHttpException
+     *
+     * @author CraftPulse
      */
     public function actionEdit(): ?Response
     {
@@ -73,16 +87,26 @@ class SettingsController extends Controller
                 'url' => UrlHelper::cpUrl('password-policy/plugin'),
             ],
         ];
-        $variables['settings'] = PasswordPolicy::$plugin->settings;
+        $variables['settings'] = PasswordPolicy::$plugin->getSettings();
 
         return $this->renderTemplate('password-policy/_settings', $variables);
     }
 
     /**
-     * Saves the plugin settings
+     * Saves the plugin settings.
+     *
+     * @return Response|null
+     *
+     * @throws BadRequestHttpException
+     * @throws ForbiddenHttpException
+     * @throws NotFoundHttpException
+     *
+     * @author CraftPulse
      */
     public function actionSave(): ?Response
     {
+        $this->requirePostRequest();
+
         // Ensure they have permission to edit the plugin settings
         $currentUser = Craft::$app->getUser()->getIdentity();
         if (!$currentUser->can('pp:settings')) {
@@ -94,7 +118,6 @@ class SettingsController extends Controller
         }
 
         // Save the plugin settings
-        $this->requirePostRequest();
         $pluginHandle = Craft::$app->getRequest()->getRequiredBodyParam('pluginHandle');
         $plugin = Craft::$app->getPlugins()->getPlugin($pluginHandle);
         $settings = Craft::$app->getRequest()->getBodyParam('settings', []);

--- a/src/helpers/PasswordResetHelper.php
+++ b/src/helpers/PasswordResetHelper.php
@@ -64,7 +64,7 @@ class PasswordResetHelper
      */
     private static function _createInterval(): ?string
     {
-        $settings = PasswordPolicy::$plugin->settings;
+        $settings = PasswordPolicy::$plugin->getSettings();
 
         return match ($settings->expiryPeriod) {
             'day' => "P{$settings->expiryAmount}D",

--- a/src/helpers/PasswordResetHelper.php
+++ b/src/helpers/PasswordResetHelper.php
@@ -12,9 +12,10 @@ namespace craftpulse\passwordpolicy\helpers;
 
 use Carbon\Carbon;
 use craft\elements\User;
+use craft\helpers\Db;
 
 use craftpulse\passwordpolicy\PasswordPolicy;
-use DateTime;
+use DateInterval;
 
 /**
  * Class PasswordResetHelper
@@ -25,68 +26,52 @@ use DateTime;
  */
 class PasswordResetHelper
 {
+    // Public Methods
+    // =========================================================================
+
     /**
-     * Returns all the users where the password should be expired.
+     * Returns all active users whose password has expired according to the retention settings.
      *
-     * @return array
+     * @return User[]
+     *
+     * @author CraftPulse
      */
     public static function getAllUsersToExpire(): array
     {
-        // make sure we have the lastPasswordChangeDate on our users
-        $users = User::find()->addSelect('lastPasswordChangeDate')->collect();
+        $interval = self::_createInterval();
 
-        // only get the active users
-        $users = $users->filter(function($user) {
-            return $user->active === true;
-        });
-
-        // now only get the ones where their password is changed at least 90 days ago (how lol?);
-        $users = $users->filter(function($user) {
-            return self::checkIfExpired($user->lastPasswordChangeDate);
-        })->all();
-
-        return $users;
-    }
-
-    private static function checkIfExpired(?DateTime $lastPasswordChangeDate = null): bool
-    {
-        if ($lastPasswordChangeDate === null) {
-            return false;
+        if ($interval === null) {
+            return [];
         }
 
-        $now = Carbon::now();
-        $interval = self::createInterval();
-        $lastPasswordChangeDate = new Carbon($lastPasswordChangeDate);
-        if ($interval) {
-            $requiredLastPasswordChangeDate = $now->subtract(self::createInterval());
-            if ($lastPasswordChangeDate->lessThan($requiredLastPasswordChangeDate)) {
-                return true;
-            };
-        }
+        $expiryDate = Carbon::now()->sub(new DateInterval($interval));
 
-        return false;
+        return User::find()
+            ->status('active')
+            ->andWhere(['<', 'users.lastPasswordChangeDate', Db::prepareDateForDb($expiryDate)])
+            ->all();
     }
 
-    private static function createInterval(): ?string
+    // Private Methods
+    // =========================================================================
+
+    /**
+     * Creates an ISO 8601 duration string from the plugin's expiry settings.
+     *
+     * @return string|null
+     *
+     * @author CraftPulse
+     */
+    private static function _createInterval(): ?string
     {
         $settings = PasswordPolicy::$plugin->settings;
-        $period = null;
 
-        switch ($settings->expiryPeriod) {
-            case 'day':
-                $period = "P{$settings->expiryAmount}D";
-                break;
-            case 'week':
-                $period = "P{$settings->expiryAmount}W";
-                break;
-            case 'month':
-                $period = "P{$settings->expiryAmount}M";
-                break;
-            case 'year':
-                $period = "P{$settings->expiryAmount}Y";
-                break;
-        }
-
-        return $period;
+        return match ($settings->expiryPeriod) {
+            'day' => "P{$settings->expiryAmount}D",
+            'week' => "P{$settings->expiryAmount}W",
+            'month' => "P{$settings->expiryAmount}M",
+            'year' => "P{$settings->expiryAmount}Y",
+            default => null,
+        };
     }
 }

--- a/src/jobs/PasswordResetJob.php
+++ b/src/jobs/PasswordResetJob.php
@@ -25,6 +25,8 @@ use yii\queue\RetryableJobInterface;
  * @author      CraftPulse
  * @package     PasswordPolicy
  * @since       5.0.0
+ *
+ * @property \yii\queue\Queue $queue
  */
 class PasswordResetJob extends BaseBatchedJob implements RetryableJobInterface
 {

--- a/src/jobs/PasswordResetJob.php
+++ b/src/jobs/PasswordResetJob.php
@@ -16,7 +16,7 @@ use craftpulse\passwordpolicy\batchers\PasswordResetBatcher;
 use craftpulse\passwordpolicy\helpers\PasswordResetHelper;
 use craftpulse\passwordpolicy\PasswordPolicy;
 
-use yii\queue\Queue;
+use Throwable;
 use yii\queue\RetryableJobInterface;
 
 /**
@@ -25,18 +25,16 @@ use yii\queue\RetryableJobInterface;
  * @author      CraftPulse
  * @package     PasswordPolicy
  * @since       5.0.0
- *
- * @property Queue $queue
  */
 class PasswordResetJob extends BaseBatchedJob implements RetryableJobInterface
 {
-    /**
-     * @var array
-     */
-    public array $users;
+    // Public Methods
+    // =========================================================================
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function init(): void
     {
@@ -48,6 +46,8 @@ class PasswordResetJob extends BaseBatchedJob implements RetryableJobInterface
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function getTtr(): int
     {
@@ -56,6 +56,8 @@ class PasswordResetJob extends BaseBatchedJob implements RetryableJobInterface
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function canRetry($attempt, $error): bool
     {
@@ -64,7 +66,14 @@ class PasswordResetJob extends BaseBatchedJob implements RetryableJobInterface
     }
 
     /**
-     * Handles setting the progress.
+     * Sets the progress for the current job.
+     *
+     * @param int $count
+     * @param int $total
+     * @param string|null $label
+     * @return void
+     *
+     * @author CraftPulse
      */
     public function setProgressHandler(int $count, int $total, string $label = null): void
     {
@@ -72,6 +81,16 @@ class PasswordResetJob extends BaseBatchedJob implements RetryableJobInterface
         $this->setProgress($this->queue, $progress, $label);
     }
 
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * Loads the batch data for processing.
+     *
+     * @return PasswordResetBatcher
+     *
+     * @author CraftPulse
+     */
     protected function loadData(): PasswordResetBatcher
     {
         $users = PasswordResetHelper::getAllUsersToExpire();
@@ -83,7 +102,14 @@ class PasswordResetJob extends BaseBatchedJob implements RetryableJobInterface
     }
 
     /**
-     * @inheritdoc
+     * Processes a single user item.
+     *
+     * @param mixed $item
+     * @return void
+     *
+     * @throws Throwable
+     *
+     * @author CraftPulse
      */
     protected function processItem(mixed $item): void
     {

--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -23,6 +23,9 @@ use craft\behaviors\EnvAttributeParserBehavior;
  */
 class SettingsModel extends Model
 {
+    // Public Properties
+    // =========================================================================
+
     /**
      * @var int the minimum length for the password, can't be lower than 6 (Craft Standard)
      */
@@ -79,10 +82,14 @@ class SettingsModel extends Model
      */
     public bool $cspNonce = false;
 
-    /**
-     * @return array[]
-     */
+    // Protected Methods
+    // =========================================================================
 
+    /**
+     * @inheritdoc
+     *
+     * @author CraftPulse
+     */
     protected function defineBehaviors(): array
     {
         return [
@@ -95,10 +102,12 @@ class SettingsModel extends Model
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     protected function defineRules(): array
     {
-        return [
+        return array_merge(parent::defineRules(), [
             [['minLength'], 'required'],
             [
                 ['minLength'],
@@ -128,12 +137,12 @@ class SettingsModel extends Model
                 },
             ],
             [
-                ['expiryPeriod'], // Replace with the name of your dropdown/select field
+                ['expiryPeriod'],
                 'in',
-                'range' => ['day', 'week', 'month', 'year'], // Define acceptable values
+                'range' => ['day', 'week', 'month', 'year'],
                 'message' => Craft::t('password-policy', 'The selected expiry period is invalid.'),
             ],
             [['cases', 'cspNonce', 'numbers', 'symbols', 'retentionUtilities'], 'boolean'],
-        ];
+        ]);
     }
 }

--- a/src/rules/UserRules.php
+++ b/src/rules/UserRules.php
@@ -24,20 +24,26 @@ use craftpulse\passwordpolicy\validators\PwnedValidator;
  */
 class UserRules
 {
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Returns the validation rules for user password fields.
+     *
+     * @return array
+     *
+     * @author CraftPulse
+     */
     public static function defineRules(): array
     {
-        $settings = PasswordPolicy::$plugin->settings;
+        $settings = PasswordPolicy::$plugin->getSettings();
 
         $rules[] =
             [
                 ['password', 'newPassword'],
                 'string',
                 'min' => $settings->minLength,
-                'tooShort' => Craft::t(
-                    'password-policy',
-                    Craft::t('password-policy','Password must contain at least {min} characters.'),
-                    ['min' => $settings->minLength]
-                ),
+                'tooShort' => Craft::t('password-policy', 'Password must contain at least {min} characters.', ['min' => $settings->minLength]),
                 'skipOnError' => false,
             ];
         $rules[] =
@@ -58,11 +64,7 @@ class UserRules
                     ['password', 'newPassword'],
                     'string',
                     'max' => $settings->maxLength,
-                    'tooLong' => Craft::t(
-                        'password-policy',
-                        Craft::t('password-policy','Password can maximum contain {max} characters.'),
-                        ['max' => $settings->maxLength]
-                    ),
+                    'tooLong' => Craft::t('password-policy', 'Password can maximum contain {max} characters.', ['max' => $settings->maxLength]),
                     'skipOnError' => false,
                 ];
         }

--- a/src/rules/UserRules.php
+++ b/src/rules/UserRules.php
@@ -43,7 +43,11 @@ class UserRules
                 ['password', 'newPassword'],
                 'string',
                 'min' => $settings->minLength,
-                'tooShort' => Craft::t('password-policy', 'Password must contain at least {min} characters.', ['min' => $settings->minLength]),
+                'tooShort' => Craft::t(
+                    'password-policy',
+                    'Password must contain at least {min} characters.',
+                    ['min' => $settings->minLength]
+                ),
                 'skipOnError' => false,
             ];
         $rules[] =
@@ -64,7 +68,11 @@ class UserRules
                     ['password', 'newPassword'],
                     'string',
                     'max' => $settings->maxLength,
-                    'tooLong' => Craft::t('password-policy', 'Password can maximum contain {max} characters.', ['max' => $settings->maxLength]),
+                    'tooLong' => Craft::t(
+                        'password-policy',
+                        'Password can maximum contain {max} characters.',
+                        ['max' => $settings->maxLength]
+                    ),
                     'skipOnError' => false,
                 ];
         }

--- a/src/services/PasswordService.php
+++ b/src/services/PasswordService.php
@@ -29,28 +29,44 @@ use yii\log\Logger;
  */
 class PasswordService extends Component
 {
+    // Constants
+    // =========================================================================
+
     public const PWNED_ENDPOINT = 'https://api.pwnedpasswords.com/range/';
+
+    // Private Properties
+    // =========================================================================
 
     /**
      * @var SettingsModel
      */
-    private SettingsModel $settings;
+    private SettingsModel $_settings;
 
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     *
+     * @author CraftPulse
+     */
     public function init(): void
     {
-        $this->settings = PasswordPolicy::$plugin->settings;
+        $this->_settings = PasswordPolicy::$plugin->getSettings();
     }
 
     /**
-     * Method the generate the password pattern.
+     * Generates a regex pattern for password validation based on the current settings.
+     *
      * @return string
+     *
+     * @author CraftPulse
      */
     public function generatePattern(): string
     {
-        // build the regexp dynamically
-        $pattern = $this->patterns()
+        $pattern = $this->_patterns()
             ->reject(function(string $value, string $key) {
-                return $this->settings->{$key} === false;
+                return $this->_settings->{$key} === false;
             })
             ->implode('');
 
@@ -58,15 +74,17 @@ class PasswordService extends Component
     }
 
     /**
-     * Method to generate the validation message.
+     * Generates a human-readable validation message based on the current settings.
+     *
      * @return string
+     *
+     * @author CraftPulse
      */
     public function generateMessage(): string
     {
-        // build the regexp dynamically
-        $message = $this->messages()
+        $message = $this->_messages()
             ->reject(function(string $value, string $key) {
-                return $this->settings->{$key} === false;
+                return $this->_settings->{$key} === false;
             })
             ->implode(', ');
 
@@ -74,8 +92,12 @@ class PasswordService extends Component
     }
 
     /**
-     * Method to validate password against the "have I been pwned" database
-     * @return bool
+     * Validates a password against the "Have I Been Pwned" database.
+     *
+     * @param string $password
+     * @return bool|null
+     *
+     * @author CraftPulse
      */
     public function pwned(string $password): ?bool
     {
@@ -101,18 +123,24 @@ class PasswordService extends Component
                     }
                 });
 
-            return $passwords->count() > 0 ? true : false;
+            return $passwords->isNotEmpty();
         } catch (GuzzleException $exception) {
             PasswordPolicy::$plugin->log($exception->getMessage(), [], Logger::LEVEL_ERROR);
             return false;
         }
     }
 
+    // Private Methods
+    // =========================================================================
+
     /**
-     * Collection of messages.
+     * Returns the collection of human-readable requirement messages.
+     *
      * @return Collection
+     *
+     * @author CraftPulse
      */
-    private function messages(): Collection
+    private function _messages(): Collection
     {
         return Collection::make([
             'cases' => Craft::t('password-policy', 'a lowercase character, an uppercase character'),
@@ -122,15 +150,18 @@ class PasswordService extends Component
     }
 
     /**
-     * Collection of regexp patterns.
+     * Returns the collection of regex patterns for password requirements.
+     *
      * @return Collection
+     *
+     * @author CraftPulse
      */
-    private function patterns(): Collection
+    private function _patterns(): Collection
     {
         return Collection::make([
             'cases' => '(?=.*[a-z])(?=.*[A-Z])',
             'numbers' => '(?=.*[0-9])',
-            'symbols' => '(?=.*[!@#\$%\^&\*])',
+            'symbols' => '(?=.*[^a-zA-Z0-9])',
         ]);
     }
 }

--- a/src/services/RetentionService.php
+++ b/src/services/RetentionService.php
@@ -17,6 +17,7 @@ use craft\helpers\Queue;
 
 use craftpulse\passwordpolicy\jobs\PasswordResetJob;
 use craftpulse\passwordpolicy\PasswordPolicy;
+use Throwable;
 
 /**
  * Class RetentionService
@@ -27,13 +28,23 @@ use craftpulse\passwordpolicy\PasswordPolicy;
  */
 class RetentionService extends Component
 {
+    // Public Properties
+    // =========================================================================
+
     /**
      * @var int
      */
     public int $resets = 0;
 
+    // Public Methods
+    // =========================================================================
+
     /**
-     * @inheritdoc
+     * Pushes a password reset job to the queue.
+     *
+     * @return void
+     *
+     * @author CraftPulse
      */
     public function resetPasswords(): void
     {
@@ -49,10 +60,20 @@ class RetentionService extends Component
         );
     }
 
+    /**
+     * Flags a user as requiring a password reset.
+     *
+     * @param UserElement $user
+     * @return void
+     *
+     * @throws Throwable
+     *
+     * @author CraftPulse
+     */
     public function requirePasswordReset(UserElement $user): void
     {
-        // In the free version we will never force the reset of our main admin account!
-        if ($user->id !== 1) {
+        // In the free version we will never force the reset of our admin accounts
+        if (!$user->admin) {
             $user->passwordResetRequired = true;
             Craft::$app->getElements()->saveElement($user);
             $this->resets++;

--- a/src/services/SecurityService.php
+++ b/src/services/SecurityService.php
@@ -7,6 +7,7 @@
  * @link      https://craftpulse.com
  * @copyright Copyright (c) 2024 CraftPulse
  */
+
 namespace craftpulse\passwordpolicy\services;
 
 use Craft;
@@ -14,7 +15,7 @@ use craft\base\Component;
 use yii\base\Exception;
 
 /**
- * Class RetentionService
+ * Class SecurityService
  *
  * @author      CraftPulse
  * @package     PasswordPolicy
@@ -22,12 +23,25 @@ use yii\base\Exception;
  */
 class SecurityService extends Component
 {
-    /** @var string|null the nonce */
-    private ?string $_nonce = null;
+    // Private Properties
+    // =========================================================================
 
     /**
-     * Generate and return the CSP nonce for this request
+     * @var string|null the nonce
+     */
+    private ?string $_nonce = null;
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Generates and returns the CSP nonce for this request.
+     *
+     * @return string
+     *
      * @throws Exception
+     *
+     * @author CraftPulse
      */
     public function getNonce(): string
     {
@@ -39,8 +53,13 @@ class SecurityService extends Component
     }
 
     /**
-     * Apply Content Security Policy with nonce for indicator script
+     * Applies a Content Security Policy header with nonce for the indicator script.
+     *
+     * @return void
+     *
      * @throws Exception
+     *
+     * @author CraftPulse
      */
     public function applyCsp(): void
     {

--- a/src/services/ServicesTrait.php
+++ b/src/services/ServicesTrait.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Password policy plugin for Craft CMS
+ *
+ * Enforce a password policy on your users. This plugin is aimed to make sure users use a password that is secure.
+ *
+ * @link      https://craftpulse.com
+ * @copyright Copyright (c) 2024 CraftPulse
+ */
 
 namespace craftpulse\passwordpolicy\services;
 
@@ -7,16 +15,27 @@ use nystudio107\pluginvite\services\VitePluginService;
 use yii\base\InvalidConfigException;
 
 /**
- * @author    craftpulse
+ * @author    CraftPulse
  * @package   Password Policy
  * @since     5.0.3
  *
  * @property PasswordService $passwords
  * @property RetentionService $retention
+ * @property SecurityService $security
  * @property VitePluginService $vite
  */
 trait ServicesTrait
 {
+    // Static Methods
+    // =========================================================================
+
+    /**
+     * Returns the component configuration for this plugin.
+     *
+     * @return array
+     *
+     * @author CraftPulse
+     */
     public static function config(): array
     {
         return [
@@ -44,10 +63,13 @@ trait ServicesTrait
     // =========================================================================
 
     /**
-     * Returns the passwords service
+     * Returns the passwords service.
      *
-     * @return PasswordService The passwords service
+     * @return PasswordService
+     *
      * @throws InvalidConfigException
+     *
+     * @author CraftPulse
      */
     public function getPasswords(): PasswordService
     {
@@ -55,10 +77,13 @@ trait ServicesTrait
     }
 
     /**
-     * Returns the retention service
+     * Returns the retention service.
      *
-     * @return RetentionService The retention service
+     * @return RetentionService
+     *
      * @throws InvalidConfigException
+     *
+     * @author CraftPulse
      */
     public function getRetention(): RetentionService
     {
@@ -66,10 +91,13 @@ trait ServicesTrait
     }
 
     /**
-     * Returns the security service
+     * Returns the security service.
      *
-     * @return SecurityService The security service
+     * @return SecurityService
+     *
      * @throws InvalidConfigException
+     *
+     * @author CraftPulse
      */
     public function getSecurity(): SecurityService
     {
@@ -77,10 +105,13 @@ trait ServicesTrait
     }
 
     /**
-     * Returns the vite service
+     * Returns the vite service.
      *
-     * @return VitePluginService The vite service
+     * @return VitePluginService
+     *
      * @throws InvalidConfigException
+     *
+     * @author CraftPulse
      */
     public function getVite(): VitePluginService
     {

--- a/src/utilities/RetentionUtility.php
+++ b/src/utilities/RetentionUtility.php
@@ -12,7 +12,6 @@ namespace craftpulse\passwordpolicy\utilities;
 
 use Craft;
 use craft\base\Utility;
-use craftpulse\passwordpolicy\PasswordPolicy;
 
 /**
  * Class RetentionUtility
@@ -23,8 +22,13 @@ use craftpulse\passwordpolicy\PasswordPolicy;
  */
 class RetentionUtility extends Utility
 {
+    // Public Methods
+    // =========================================================================
+
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public static function displayName(): string
     {
@@ -33,6 +37,8 @@ class RetentionUtility extends Utility
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public static function id(): string
     {
@@ -41,6 +47,8 @@ class RetentionUtility extends Utility
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public static function icon(): ?string
     {
@@ -49,18 +57,27 @@ class RetentionUtility extends Utility
 
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public static function contentHtml(): string
     {
         return Craft::$app->getView()->renderTemplate('password-policy/_utilities/retention', [
-            'actions' => self::getActions(),
+            'actions' => self::_getActions(),
         ]);
     }
 
+    // Private Methods
+    // =========================================================================
+
     /**
+     * Returns the available retention actions.
+     *
      * @return array
+     *
+     * @author CraftPulse
      */
-    public static function getActions(): array
+    private static function _getActions(): array
     {
         $actions = [];
 

--- a/src/validators/PwnedValidator.php
+++ b/src/validators/PwnedValidator.php
@@ -23,13 +23,18 @@ use yii\validators\Validator;
  */
 class PwnedValidator extends Validator
 {
+    // Public Methods
+    // =========================================================================
+
     /**
      * @inheritdoc
+     *
+     * @author CraftPulse
      */
     public function validateValue($value): ?array
     {
         if (PasswordPolicy::$plugin->passwords->pwned($value)) {
-            return [Craft::t('password-policy','This password has been compromised in a data breach. Please choose another password.'), []];
+            return [Craft::t('password-policy', 'This password has been compromised in a data breach. Please choose another password.'), []];
         }
 
         return null;


### PR DESCRIPTION
## Summary

Comprehensive quality sweep addressing 16 issues — security vulnerabilities, bugs, and coding convention enforcement across the entire plugin.

### Security (Critical)
- **#47** — `RetentionController` had CSRF disabled + `$allowAnonymous = true`, allowing unauthenticated mass password resets. Locked down to require CP request, POST, and `pp:force-reset-passwords` permission.
- **#48** — `afterAction()` was synchronously draining the entire queue on every web request. Removed entirely.
- **#49** — Admin exclusion was hardcoded to `$user->id !== 1`. Now uses `$user->admin`.
- **#50** — `getAllUsersToExpire()` hydrated every user in the system before filtering in PHP. Now pushes the date comparison into the DB query and scopes to active users.

### Bug Fixes
- **#54** — `getCpNavItem()` null dereference when no user is authenticated.
- **#55** — Static `$settings` property removed (was never populated, dead code). All access now goes through `getSettings()`.
- **#56** — `requirePostRequest()` moved before permission checks in `SettingsController::actionSave()`.
- **#59** — `SettingsModel::defineRules()` now calls `parent::defineRules()`.
- **#60** — Console controller returns `ExitCode::UNSPECIFIED_ERROR` when retention is disabled. `--queue` flag now actually controls behavior: default runs synchronously, `--queue` pushes to queue.
- **#61** — Removed double `Craft::t()` nesting in `UserRules` that broke non-English translations.
- **#46** — Symbols regex changed from `[!@#$%^&*]` to `[^a-zA-Z0-9]` so hyphens, underscores, and all non-alphanumeric characters are accepted.

### Code Quality (#62, #57, #58)
- Replaced `switch` with `match` in `PasswordResetHelper::_createInterval()`
- Replaced redundant ternary with `isNotEmpty()` in `PasswordService::pwned()`
- Fixed `$queue` property type from `mixed|object|null` to `?object`
- Removed dead `$vacancyId` parameter from `RetentionController::_getFailureResponse()`
- Removed no-op `EVENT_AFTER_SAVE_PLUGIN_SETTINGS` handler
- Added PHPDoc to `PasswordResetBatcher` constructor
- Fixed `PasswordPolicyAsset` to use `getView()` instead of property access
- Fixed `SecurityService` docblock (said "RetentionService")
- Removed dead `$users` property from `PasswordResetJob`

### Conventions (#51, #52, #53)
- Added section headers to all files
- Added `@author CraftPulse` to all public/protected/private methods
- Added `@throws` annotations across controllers, services, helpers, and jobs
- Applied underscore prefix convention to all private methods/properties

Closes #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62